### PR TITLE
Rename RequestCounter to RequestMetrics

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -12,7 +12,7 @@ import (
 
 var defaultBuckets = []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000}
 
-// RequestCounter tracks request counts and latencies partitioned by response
+// RequestMetrics tracks request counts and latencies partitioned by response
 // code, HTTP method and path.
 //
 // The provided service should be unique to each tracked service. The registry
@@ -24,7 +24,7 @@ var defaultBuckets = []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 1
 //
 // For accuracy, buckets should mirror the distribution of the latencies of the service.
 // See https://github.com/danielfm/prometheus-for-developers#quantile-estimation-errors
-func RequestCounter(
+func RequestMetrics(
 	service string,
 	registry prometheus.Registerer,
 	buckets ...float64,

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -21,10 +21,10 @@ type requestMetric struct {
 	Help string `json:"help"`
 }
 
-func TestRequestCounter(t *testing.T) {
+func TestRequestMetrics(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	r := chi.NewRouter()
-	r.Use(RequestCounter("test", registry))
+	r.Use(RequestMetrics("test", registry))
 	r.Route("/root", func(r chi.Router) {
 		r.Get("/sub", nilHandler)
 		r.Route("/{param}", func(r chi.Router) {


### PR DESCRIPTION
Called out from a separate PR integrating this package, RequestCounter doesn't adequately imply that we also track latencies.